### PR TITLE
Fix an issue building with MPI and without BOOST_BIND_GLOBAL_PLACEHOLDERS

### DIFF
--- a/include/boost/property_map/parallel/impl/distributed_property_map.ipp
+++ b/include/boost/property_map/parallel/impl/distributed_property_map.ipp
@@ -11,7 +11,7 @@
 #include <boost/property_map/parallel/distributed_property_map.hpp>
 #include <boost/property_map/parallel/detail/untracked_pair.hpp>
 #include <boost/type_traits/is_base_and_derived.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/property_map/parallel/simple_trigger.hpp>
 
 namespace boost { namespace parallel {


### PR DESCRIPTION
Using [bdde](https://github.com/jeking3/bdde) I have a docker-based build environment that enables optional features like MPI.  It looks like boost/bind changed such that you need to define `BOOST_BIND_GLOBAL_PLACEHOLDERS` if you want to include `<boost/bind.hpp>`, or you need to include `<boost/bind/bind.hpp>`; so I changed the code to the latter.

Without the fix the following error would occur:

```
gcc.compile.c++ bin.v2/libs/graph_parallel/build/gcc-9/release/link-static/local-visibility-global/threading-multi/visibility-hidden/mpi_process_group.o
In file included from ./boost/property_map/parallel/distributed_property_map.hpp:689,
                 from ./boost/property_map/parallel/parallel_property_maps.hpp:30,
                 from ./boost/property_map/property_map.hpp:602,
                 from ./boost/graph/properties.hpp:19,
                 from ./boost/mpi/graph_communicator.hpp:30,
                 from ./boost/mpi.hpp:27,
                 from ./boost/graph/distributed/mpi_process_group.hpp:30,
                 from libs/graph_parallel/src/mpi_process_group.cpp:14:
./boost/property_map/parallel/impl/distributed_property_map.ipp:14:10: fatal error: boost/bind.hpp: No such file or directory
   14 | #include <boost/bind.hpp>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.

    "g++"   -m64 -pthread -O3 -finline-functions -Wno-inline -Wall -fvisibility=default  -DBOOST_ALL_NO_LIB=1 -DBOOST_GRAPH_NO_LIB=1 -DNDEBUG  -I"." -I"/usr/lib/x86_64-linux-gnu/openmpi/include" -I"/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi" -I"libs/graph_parallel/src"  -c -o "bin.v2/libs/graph_parallel/build/gcc-9/release/link-static/local-visibility-global/threading-multi/visibility-hidden/mpi_process_group.o" "libs/graph_parallel/src/mpi_process_group.cpp"

...failed gcc.compile.c++ bin.v2/libs/graph_parallel/build/gcc-9/release/link-static/local-visibility-global/threading-multi/visibility-hidden/mpi_process_group.o...
```