### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,32 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/property_map_parallel
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/function//boost_function
+        <source>/boost/mpi//boost_mpi
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_index//boost_multi_index
+        <source>/boost/optional//boost_optional
+        <source>/boost/property_map//boost_property_map
+        <source>/boost/serialization//boost_serialization
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_property_map_parallel ]
+    [ alias all : boost_property_map_parallel ]
+    ;
+
+call-if : boost-library property_map_parallel
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/property_map_parallel

--- a/build.jam
+++ b/build.jam
@@ -5,28 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/function//boost_function
+    /boost/mpi//boost_mpi
+    /boost/mpl//boost_mpl
+    /boost/multi_index//boost_multi_index
+    /boost/optional//boost_optional
+    /boost/property_map//boost_property_map
+    /boost/serialization//boost_serialization
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/property_map_parallel
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/function//boost_function
-        <library>/boost/mpi//boost_mpi
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_index//boost_multi_index
-        <library>/boost/optional//boost_optional
-        <library>/boost/property_map//boost_property_map
-        <library>/boost/serialization//boost_serialization
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_property_map_parallel ]
+    [ alias boost_property_map_parallel : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_property_map_parallel ]
     ;
 
 call-if : boost-library property_map_parallel
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,19 +7,19 @@ import project ;
 
 project /boost/property_map_parallel
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/function//boost_function
-        <source>/boost/mpi//boost_mpi
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_index//boost_multi_index
-        <source>/boost/optional//boost_optional
-        <source>/boost/property_map//boost_property_map
-        <source>/boost/serialization//boost_serialization
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/function//boost_function
+        <library>/boost/mpi//boost_mpi
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_index//boost_multi_index
+        <library>/boost/optional//boost_optional
+        <library>/boost/property_map//boost_property_map
+        <library>/boost/serialization//boost_serialization
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/property_map_parallel
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -21,12 +21,11 @@ constant boost_dependencies :
     /boost/type_traits//boost_type_traits ;
 
 project /boost/property_map_parallel
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_property_map_parallel : : : : <library>$(boost_dependencies) ]
+    [ alias boost_property_map_parallel : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_property_map_parallel ]
     ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.