### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(boost_property_map_parallel
     Boost::property_map
     Boost::serialization
     Boost::smart_ptr
-    Boost::static_assert
     Boost::type_traits
 )
 

--- a/build.jam
+++ b/build.jam
@@ -17,7 +17,6 @@ constant boost_dependencies :
     /boost/property_map//boost_property_map
     /boost/serialization//boost_serialization
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits ;
 
 project /boost/property_map_parallel


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.